### PR TITLE
General improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM python:3.7.1
 
 WORKDIR /opt/testing
 
+RUN groupadd -r celery --gid 1000 && useradd --no-log-init -r -g celery --uid 1000 celery
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-CMD ["celery", "worker", "-A", "tasks", "--loglevel=info", "-Q", "behave", "-c", "1"]
+CMD ["celery", "worker", "--uid", "celery", "--app", "tasks", "--loglevel", "debug", "--queues", "behave", "--concurrency", "1"]

--- a/behave/environment.py
+++ b/behave/environment.py
@@ -1,21 +1,47 @@
-from selenium.webdriver.remote import webdriver
+# -*- coding: utf-8 -*-
+import os
 
-WEBDRIVER_URL = 'http://selenium-hub:4444/wd/hub'
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
 
-DEFAULT_BROWSER = 'firefox'
-
+HUB_URL = os.environ.get("HUB_URL", "http://selenium-hub:4444/wd/hub")
+BROWSER = os.environ.get("BROWSER", "firefox")
 DESIRED_CAPABILITIES = {
-    'platform': 'ANY',
-    'browserName': DEFAULT_BROWSER,
-    'version': '',
-    'javascriptEnabled': True
+    "platform": "ANY",
+    "browserName": BROWSER,
+    "version": "",
+    "javascriptEnabled": True,
 }
 
 
 def before_all(context):
-    context.browser = webdriver.WebDriver(
-        WEBDRIVER_URL,
-        desired_capabilities=DESIRED_CAPABILITIES
+
+    browser = DESIRED_CAPABILITIES["browserName"].lower()
+
+    if browser == "chrome":
+        options = ChromeOptions()
+        options.add_argument("--headless")
+        options.add_argument("--window-size=1600x2200")
+        options.add_argument("--start-maximized")
+        options.add_argument("--whitelisted-ips=")
+        options.add_argument("--disable-extensions")
+        options.add_argument("--no-sandbox")
+    elif browser == "firefox":
+        options = FirefoxOptions()
+        # see comment in docker-compose.yml re: bug in geckodriver
+        # options.add_argument("--headless")
+        # options.add_argument("--window-size 1600,2200")
+        options.add_argument("--width=1600")
+        options.add_argument("--height=2200")
+        options.add_argument("--safe-mode")
+    else:
+        raise Exception(f"{browser} is not supported try: Chrome or Firefox")
+
+    context.browser = webdriver.Remote(
+        command_executor=HUB_URL,
+        desired_capabilities=DESIRED_CAPABILITIES,
+        options=options,
     )
 
 

--- a/behave/environment.py
+++ b/behave/environment.py
@@ -45,5 +45,5 @@ def before_all(context):
     )
 
 
-def after_all(context):
+def after_scenario(context, scenario):
     context.browser.quit()

--- a/behave/steps/example.py
+++ b/behave/steps/example.py
@@ -2,12 +2,12 @@ from behave import given, when, then
 from time import sleep
 
 
-@given('I am logged as {} user')
+@given("I am logged as {} user")
 def step_impl(context, user):
     pass
 
 
-@when('I create Staff user')
+@when("I create Staff user")
 def step_impl(context):
     sleep(1)
 
@@ -22,17 +22,17 @@ def step_impl(context):
     sleep(2)
 
 
-@when('I remove Staff user')
+@when("I remove Staff user")
 def step_impl(context):
     sleep(2)
 
 
-@then('Staff user is visible on user list page')
+@then("Staff user is visible on user list page")
 def step_impl(context):
     sleep(2)
 
 
-@then('I should be able to login as Staff user')
+@then("I should be able to login as Staff user")
 def step_impl(context):
     sleep(2)
 
@@ -42,17 +42,17 @@ def step_impl(context):
     sleep(2)
 
 
-@then('Staff user is not visible on user list page')
+@then("Staff user is not visible on user list page")
 def step_impl(context):
     sleep(2)
 
 
-@when('I create new group')
+@when("I create new group")
 def step_impl(context):
     sleep(5)
 
 
-@then('Created group is visible on the list')
+@then("Created group is visible on the list")
 def step_impl(context):
     sleep(1)
 
@@ -67,12 +67,12 @@ def step_impl(context):
     sleep(1)
 
 
-@when('I remove previously created group')
+@when("I remove previously created group")
 def step_impl(context):
     sleep(3)
 
 
-@then('Group is not visible on the list')
+@then("Group is not visible on the list")
 def step_impl(context):
     sleep(1)
-    assert False, 'something went wrong'
+    assert False, "something went wrong"

--- a/behave/steps/tutorial.py
+++ b/behave/steps/tutorial.py
@@ -1,17 +1,18 @@
 from behave import given, when, then
 from time import sleep
 
-@given('we have behave installed')
+
+@given("we have behave installed")
 def step_impl(context):
     pass
 
 
-@when('we implement a test')
+@when("we implement a test")
 def step_impl(context):
     assert True is not False
 
 
-@then('selenium works!')
+@then("selenium works!")
 def step_impl(context):
     sleep(10)
-    context.browser.get('http://google.com')
+    context.browser.get("http://google.com")

--- a/behave_ext/mini_formatter.py
+++ b/behave_ext/mini_formatter.py
@@ -18,6 +18,16 @@ class MiniFormatter(Formatter):
     RAISE_OUTPUT_ERRORS = True
 
     def scenario(self, scenario):
-        text = u"%s: %s" % (scenario.keyword, scenario.name)
-        self.stream.write(text)
-        self.stream.write(u"\n")
+        skip_config_tags = [
+            tag.replace("-", "")
+            for tag in str(self.config.tags).split()
+            if tag.startswith("-")
+        ]
+        has_feature_skip_tags = any(
+            skip_tag in scenario.feature.tags for skip_tag in skip_config_tags
+        )
+        has_scenario_skip_tags = any(
+            skip_tag in scenario.tags for skip_tag in skip_config_tags
+        )
+        if not has_scenario_skip_tags and not has_feature_skip_tags:
+            self.stream.write(f"{scenario.name}\n")

--- a/behave_ext/mini_formatter.py
+++ b/behave_ext/mini_formatter.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
 from behave.formatter.base import Formatter
 
 
@@ -9,6 +7,7 @@ class MiniFormatter(Formatter):
     Provides a simple plain formatter without coloring/formatting.
     The formatter displays only scenario name
     """
+
     name = "plain"
     description = "Very basic formatter with maximum compatibility"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
-version: "3"
+version: "3.7"
 services:
+
   selenium-hub:
     image: selenium/hub:3.141.5-astatine
     container_name: selenium-hub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,15 @@ services:
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT=4444
+# there's a bug in geckodriver https://github.com/mozilla/geckodriver/issues/1354
+# that unfortunately doesn't allow for changing screen resolution of headless 
+# FF and thus ATM we have to run it in XVFB
+# This way we can take hi-res screenshots. Otherwise when you use headless FF
+# then screenshot resolution will be only 1356x694px or similar!
+#      - START_XVFB=false
+      - SCREEN_WIDTH=1600
+      - SCREEN_HEIGHT=2200
+
   chrome:
     image: selenium/node-chrome:3.141.5-astatine
     networks:
@@ -49,6 +58,10 @@ services:
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT=4444
+      - START_XVFB=false
+      - SCREEN_WIDTH=1600
+      - SCREEN_HEIGHT=2200
+
   rabbit:
     image: "rabbitmq:3-management"
     hostname: "rabbit"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
 
   firefox:
     image: selenium/node-firefox:3.141.5-astatine
+    volumes:
+      - /dev/shm:/dev/shm
     depends_on:
       - selenium-hub
     healthcheck:
@@ -27,6 +29,8 @@ services:
       - HUB_PORT=4444
   chrome:
     image: selenium/node-chrome:3.141.5-astatine
+    volumes:
+      - /dev/shm:/dev/shm
     depends_on:
       - selenium-hub
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   selenium-hub:
     image: selenium/hub:3.141.5-astatine
     container_name: selenium-hub
+    networks:
+      - grid
     healthcheck:
         test: ["CMD", "/opt/bin/check-grid.sh", "--host", "0.0.0.0", "--port", "4444"]
         interval: 5s
@@ -15,6 +17,8 @@ services:
 
   firefox:
     image: selenium/node-firefox:3.141.5-astatine
+    networks:
+      - grid
     volumes:
       - /dev/shm:/dev/shm
     depends_on:
@@ -30,6 +34,8 @@ services:
       - HUB_PORT=4444
   chrome:
     image: selenium/node-chrome:3.141.5-astatine
+    networks:
+      - grid
     volumes:
       - /dev/shm:/dev/shm
     depends_on:
@@ -46,6 +52,8 @@ services:
   rabbit1:
     image: "rabbitmq:3-management"
     hostname: "rabbit1"
+    networks:
+      - grid
     environment:
       RABBITMQ_ERLANG_COOKIE: "SWQOKODSQALRPCLNMEQG"
       RABBITMQ_DEFAULT_USER: "rabbitmq"
@@ -58,6 +66,9 @@ services:
       NAME: "rabbitmq1"
   worker:
     build: .
+    networks:
+      - grid
+      - queue
     environment:
       PYTHONPATH: "/opt/testing"
     volumes:
@@ -65,9 +76,18 @@ services:
   flower:
     build: flower
     command: flower --address=0.0.0.0 --port=5555 --broker_api=http://rabbitmq:rabbitmq@rabbit1:15672/api/
+    networks:
+      - grid
+      - queue
     environment:
         - CELERY_BROKER_URL=pyamqp://rabbitmq:rabbitmq@rabbit1//
     links:
         - rabbit1
     ports:
         - "5555:5555"
+
+
+networks:
+  grid:
+  queue:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,9 +49,9 @@ services:
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT=4444
-  rabbit1:
+  rabbit:
     image: "rabbitmq:3-management"
-    hostname: "rabbit1"
+    hostname: "rabbit"
     networks:
       - grid
     environment:
@@ -62,8 +62,7 @@ services:
     ports:
       - "15672:15672"
       - "5672:5672"
-    labels:
-      NAME: "rabbitmq1"
+
   worker:
     build: .
     networks:
@@ -75,14 +74,14 @@ services:
             - .:/opt/testing
   flower:
     build: flower
-    command: flower --address=0.0.0.0 --port=5555 --broker_api=http://rabbitmq:rabbitmq@rabbit1:15672/api/
     networks:
       - grid
       - queue
+    command: flower --address=0.0.0.0 --port=5555 --broker_api=http://rabbitmq:rabbitmq@rabbit:15672/api/
     environment:
-        - CELERY_BROKER_URL=pyamqp://rabbitmq:rabbitmq@rabbit1//
+        - CELERY_BROKER_URL=pyamqp://rabbitmq:rabbitmq@rabbit//
     links:
-        - rabbit1
+        - rabbit
     ports:
         - "5555:5555"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,25 @@ services:
   selenium-hub:
     image: selenium/hub:3.141.5-astatine
     container_name: selenium-hub
+    healthcheck:
+        test: ["CMD", "/opt/bin/check-grid.sh", "--host", "0.0.0.0", "--port", "4444"]
+        interval: 5s
+        timeout: 10s
+        retries: 2
+        start_period: 40s
     ports:
       - "4444:4444"
+
   firefox:
     image: selenium/node-firefox:3.141.5-astatine
     depends_on:
       - selenium-hub
+    healthcheck:
+        test: ["CMD", "/opt/bin/check-grid.sh", "--host", "selenium-hub", "--port", "4444"]
+        interval: 5s
+        timeout: 5s
+        retries: 2
+        start_period: 40s
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT=4444
@@ -16,6 +29,12 @@ services:
     image: selenium/node-chrome:3.141.5-astatine
     depends_on:
       - selenium-hub
+    healthcheck:
+        test: ["CMD", "/opt/bin/check-grid.sh", "--host", "selenium-hub", "--port", "4444"]
+        interval: 5s
+        timeout: 5s
+        retries: 2
+        start_period: 40s
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT=4444

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,8 @@ services:
     environment:
       PYTHONPATH: "/opt/testing"
     volumes:
-            - .:/opt/testing
+        - .:/opt/testing
+
   flower:
     build: flower
     networks:

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 allure-behave
 behave
+black
 celery
 docker-compose
 selenium

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,14 +7,16 @@
 allure-behave==2.5.3
 allure-python-commons==2.5.3  # via allure-behave
 amqp==2.3.2               # via kombu
-attrs==18.2.0             # via allure-python-commons
+appdirs==1.4.3            # via black
+attrs==18.2.0             # via allure-python-commons, black
 behave==1.2.6
 billiard==3.5.0.4         # via celery
+black==18.9b0
 cached-property==1.5.1    # via docker-compose
 celery==4.2.1
 certifi==2018.10.15       # via requests
 chardet==3.0.4            # via requests
-click==7.0                # via pip-tools
+click==7.0                # via black, pip-tools
 docker-compose==1.23.1
 docker-pycreds==0.3.0     # via docker
 docker==3.5.1             # via docker-compose
@@ -29,10 +31,11 @@ pip-tools==3.1.0
 pluggy==0.8.0             # via allure-python-commons
 pytz==2018.7              # via celery
 pyyaml==3.13              # via docker-compose
-requests==2.20.0          # via docker, docker-compose
+requests==2.20.1          # via docker, docker-compose
 selenium==3.141.0
 six==1.11.0               # via allure-python-commons, behave, docker, docker-compose, docker-pycreds, dockerpty, parse-type, pip-tools, websocket-client
 texttable==0.9.1          # via docker-compose
+toml==0.10.0              # via black
 urllib3==1.24.1           # via requests, selenium
 vine==1.1.4               # via amqp
 websocket-client==0.54.0  # via docker, docker-compose

--- a/run_test.py
+++ b/run_test.py
@@ -1,11 +1,12 @@
+# -*- coding: utf-8 -*-
 import sys
 
 from tasks import delegate_test
 
 
-def main(scenario):
-    delegate_test.delay(scenario)
+def main(browser: str, scenario: str):
+    delegate_test.delay(browser, scenario)
 
 
-if __name__ == '__main__':
-    main(sys.argv[1])
+if __name__ == "__main__":
+    main(browser=sys.argv[1], scenario=sys.argv[2])

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-docker-compose exec worker behave -d -f mini behave/features/ --no-summary | while read -r line ; do
-  docker-compose exec -d worker python3 run_test.py "$line"
+docker-compose exec worker sh -c "behave --dry-run -f mini --no-summary --tags=-wip behave/features/django_admin/" | while read -r line ; do
+  docker-compose exec -d worker python3 run_test.py "chrome" "${line}"
+  docker-compose exec -d worker python3 run_test.py "firefox" "${line}"
   echo $line
 done

--- a/tasks.py
+++ b/tasks.py
@@ -21,9 +21,6 @@ REPLACE_CHARS = ("Scenario: ", "Scenario Outline: ", "\r")
 def set_env(environ: Dict[str, str]):
     """Temporarily set the process environment variables.
 
-    def replace_char(string):
-        for char in REPLACE_CHARS:
-            string = string.replace(char, '')
     SRC: https://stackoverflow.com/a/34333710
     """
     old_environ = dict(os.environ)
@@ -43,6 +40,9 @@ def set_env(environ: Dict[str, str]):
     broker_pool_limit=None,
 )
 def delegate_test(self, browser: str, scenario: str):
+    def replace_char(string: str) -> str:
+        for chars in REPLACE_CHARS:
+            string = string.replace(chars, "")
         return string
 
     argstable = [

--- a/tasks.py
+++ b/tasks.py
@@ -6,16 +6,12 @@ from behave.__main__ import main as behave_main
 
 from io import StringIO
 
-app.conf.task_default_queue = 'behave'
 app = Celery("tasks", broker="pyamqp://rabbitmq:rabbitmq@rabbit//")
+app.conf.task_default_queue = "behave"
 app.conf.send_events = True
 app.conf.send_task_sent_event = True
 
-REPLACE_CHARS = (
-    'Scenario: ',
-    'Scenario Outline: ',
-    '\r',
-)
+REPLACE_CHARS = ("Scenario: ", "Scenario Outline: ", "\r")
 
 
 @app.task(bind=True)
@@ -42,12 +38,10 @@ def delegate_test(self, scenario):
     sys.stdout = old_stdout
     behave_result = io.getvalue()
 
-    if '1 scenario passed' not in behave_result:
+    if "1 scenario passed" not in behave_result:
         # manually update the task state
-        self.update_state(
-            state=states.FAILURE,
-            meta=behave_result
-        )
+        self.update_state(state=states.FAILURE, meta=behave_result)
 
         raise Exception(behave_result)
-    return 'Pass'
+    return "Pass"
+

--- a/tasks.py
+++ b/tasks.py
@@ -23,12 +23,18 @@ def delegate_test(self, scenario):
         return string
 
     argstable = [
-        'behave/features/django_admin/',
-        '-n', '{}{}'.format(replace_char(scenario), '$' if 'Outline' not in scenario else ''),
-        '-f', 'allure_behave.formatter:AllureFormatter',
-        '-f', 'pretty',
-        '-o', '%allure_result_folder%',
-        '--no-skipped']
+        "behave/features/django_admin/",
+        "--no-skipped",
+        "--format",
+        "pretty",
+        # disable allure reports for now as hundreds of unnecessary json
+        # reports are being generated
+        #'--format', 'allure',
+        #'--outfile', 'allure_results',
+        "--logging-filter=-root",
+        "--name",
+        replace_char(scenario),
+    ]
 
     old_stdout = sys.stdout
     io = StringIO()

--- a/tasks.py
+++ b/tasks.py
@@ -17,7 +17,6 @@ app.conf.send_task_sent_event = True
 REPLACE_CHARS = ("Scenario: ", "Scenario Outline: ", "\r")
 
 
-@app.task(bind=True)
 @contextlib.contextmanager
 def set_env(environ: Dict[str, str]):
     """Temporarily set the process environment variables.
@@ -36,6 +35,13 @@ def set_env(environ: Dict[str, str]):
         os.environ.update(old_environ)
 
 
+@app.task(
+    bind=True,
+    autoretry_for=(Exception,),
+    retry_kwargs={"max_retries": 3},
+    retry_backoff=10,
+    broker_pool_limit=None,
+)
 def delegate_test(self, browser: str, scenario: str):
         return string
 

--- a/tasks.py
+++ b/tasks.py
@@ -6,8 +6,8 @@ from behave.__main__ import main as behave_main
 
 from io import StringIO
 
-app = Celery('tasks', broker='pyamqp://rabbitmq:rabbitmq@rabbit1//')
 app.conf.task_default_queue = 'behave'
+app = Celery("tasks", broker="pyamqp://rabbitmq:rabbitmq@rabbit//")
 app.conf.send_events = True
 app.conf.send_task_sent_event = True
 


### PR DESCRIPTION
List of changes:

* run as non-root use
* reformat with [black](https://black.readthedocs.io/en/stable/)
* add docker healthchecks to browsers & hub
* run chrome in headless mode (helps to shave off a bit of time)
* add `tag` support to `mini formatter`
* add support for `chrome` in behave's config (`environment.py`)
* more instructions & tips